### PR TITLE
Allow multi-line input for the Experience text area

### DIFF
--- a/components/ClassHeading.js
+++ b/components/ClassHeading.js
@@ -557,7 +557,7 @@ const ClassHeading = ({
 					</div>
 					<div className="experience my-3">
 						<h1 className="text-xl font-semibold text-logo-red">Experience</h1>
-						<p className="text-md text-gray-700">{experience}</p>
+						<p className="text-md text-gray-700 whitespace-pre-line">{experience}</p>
 					</div>
 					<div className="description my-3">
 						<h1 className="text-xl font-semibold text-logo-red">


### PR DESCRIPTION
The createClass.js was already correct, the text area already allowed for several lines of input and allowed for breaklines.

The main issue was in ClassHeading.js, the experience paragraph tag, was not handline the break lines correctly, to fix this I have added a tailwind class whitespace-pre-line to the para tag which ensures the break lines are handled correctly

Before:
![image](https://github.com/user-attachments/assets/6e045d7a-5b01-468e-8719-8e8c47201e78)

Now:
![image](https://github.com/user-attachments/assets/3939c955-d449-4f73-bf44-1968d3975b10)
